### PR TITLE
Reduce history sidebar width and show chat sessions

### DIFF
--- a/src/components/agent/EnhancedAgentOrchestrator.tsx
+++ b/src/components/agent/EnhancedAgentOrchestrator.tsx
@@ -256,7 +256,7 @@ AI Detected: ${result.aiDetected ? 'Yes' : 'No'} (${((result.aiConfidence || 0) 
 
   return (
     <div className="mx-auto max-w-[1400px] px-2 sm:px-4 md:px-6 overflow-x-hidden">
-      <div className="flex flex-col lg:grid lg:grid-cols-[300px,1fr] gap-3 lg:gap-6 h-[calc(100vh-120px)] lg:h-[calc(100vh-180px)]">
+      <div className="flex flex-col lg:grid lg:grid-cols-[220px,1fr] gap-3 lg:gap-6 h-[calc(100vh-120px)] lg:h-[calc(100vh-180px)]">
         {/* History Sidebar - Hidden on mobile, shown on desktop */}
         <div className="hidden lg:block">
           <HistorySidebar

--- a/src/components/agent/EnhancedAgentOrchestrator.tsx
+++ b/src/components/agent/EnhancedAgentOrchestrator.tsx
@@ -256,7 +256,7 @@ AI Detected: ${result.aiDetected ? 'Yes' : 'No'} (${((result.aiConfidence || 0) 
 
   return (
     <div className="mx-auto max-w-[1400px] px-2 sm:px-4 md:px-6 overflow-x-hidden">
-      <div className="flex flex-col lg:grid lg:grid-cols-[220px,1fr] gap-3 lg:gap-6 h-[calc(100vh-120px)] lg:h-[calc(100vh-180px)]">
+      <div className="flex flex-col lg:grid lg:grid-cols-[180px,1fr] gap-3 lg:gap-6 h-[calc(100vh-120px)] lg:h-[calc(100vh-180px)]">
         {/* History Sidebar - Hidden on mobile, shown on desktop */}
         <div className="hidden lg:block">
           <HistorySidebar

--- a/src/components/agent/HistorySidebar.tsx
+++ b/src/components/agent/HistorySidebar.tsx
@@ -6,31 +6,98 @@ interface HistorySidebarProps {
   onNewChat: () => void;
 }
 
+interface ChatSession {
+  id: string;
+  title: string;
+  lastMessage: string;
+  timestamp: number;
+  messageCount: number;
+}
+
 export function HistorySidebar({ messages, onNewChat }: HistorySidebarProps) {
-  const userMessages = messages.filter((m) => m.role === "you");
+  // Group messages into sessions based on conversation flow
+  const createChatSessions = (): ChatSession[] => {
+    if (messages.length === 0) return [];
+
+    const sessions: ChatSession[] = [];
+    let currentSession: Message[] = [];
+    let sessionCounter = 1;
+
+    // Group messages by conversation breaks
+    messages.forEach((message, index) => {
+      currentSession.push(message);
+
+      // If this is the last message or there's a significant time gap, end the session
+      const nextMessage = messages[index + 1];
+      const isLastMessage = index === messages.length - 1;
+      const hasTimeGap = nextMessage && (nextMessage.ts - message.ts > 30 * 60 * 1000); // 30 minutes
+
+      if (isLastMessage || hasTimeGap) {
+        const userMessages = currentSession.filter(m => m.role === "you");
+        if (userMessages.length > 0) {
+          const firstUserMessage = userMessages[0];
+          const lastMessage = currentSession[currentSession.length - 1];
+
+          sessions.push({
+            id: `session-${sessionCounter}`,
+            title: firstUserMessage.text.slice(0, 30) + (firstUserMessage.text.length > 30 ? "..." : ""),
+            lastMessage: lastMessage.text.slice(0, 40) + (lastMessage.text.length > 40 ? "..." : ""),
+            timestamp: firstUserMessage.ts,
+            messageCount: currentSession.length
+          });
+          sessionCounter++;
+        }
+        currentSession = [];
+      }
+    });
+
+    return sessions.reverse(); // Show most recent first
+  };
+
+  const chatSessions = createChatSessions();
+
+  const formatTimeAgo = (timestamp: number) => {
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / (1000 * 60));
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    return `${days}d ago`;
+  };
 
   return (
-    <aside className="rounded-2xl border border-white/10 bg-white/5 p-4 h-[calc(100vh-180px)] overflow-y-auto scrollbar-invisible">
+    <aside className="rounded-2xl border border-white/10 bg-white/5 p-3 h-[calc(100vh-180px)] overflow-y-auto scrollbar-invisible">
       <div className="flex items-center justify-between mb-3">
         <div className="text-sm opacity-80">History</div>
         <button
           onClick={onNewChat}
-          className="text-[11px] px-2 py-1 rounded-full border border-white/15 bg-white/5 hover:bg-white/10 transition-colors"
+          className="text-[10px] px-1.5 py-0.5 rounded-full border border-white/15 bg-white/5 hover:bg-white/10 transition-colors"
           title="Start a new chat"
         >
           New
         </button>
       </div>
 
-      {userMessages.length === 0 ? (
+      {chatSessions.length === 0 ? (
         <p className="text-xs opacity-60">
-          There are no interactions yet. Write the prompt on the right.
+          No chat sessions yet. Start a conversation!
         </p>
       ) : (
-        <ul className="space-y-2 pr-1">
-          {userMessages.map((message, index) => (
-            <li key={index} className="text-sm line-clamp-2 hover:bg-white/5 rounded-lg p-2 -m-2 transition-colors cursor-pointer">
-              {message.text}
+        <ul className="space-y-1.5">
+          {chatSessions.map((session) => (
+            <li key={session.id} className="hover:bg-white/5 rounded-lg p-2 -m-2 transition-colors cursor-pointer group">
+              <div className="text-xs font-medium text-white line-clamp-2 mb-1">
+                {session.title}
+              </div>
+              <div className="text-[10px] opacity-60 line-clamp-1 mb-1">
+                {session.lastMessage}
+              </div>
+              <div className="flex items-center justify-between text-[9px] opacity-50">
+                <span>{formatTimeAgo(session.timestamp)}</span>
+                <span>{session.messageCount} msgs</span>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Purpose

Based on user feedback, the history sidebar was too wide and needed to display chat sessions instead of individual chat messages. The user requested reducing the column width and restructuring the history to show conversation sessions rather than individual message history.

## Code changes

- **Reduced sidebar width**: Changed grid column width from `300px` to `180px` in `EnhancedAgentOrchestrator.tsx`
- **Implemented chat sessions**: Added `ChatSession` interface and `createChatSessions()` function to group messages into conversation sessions
- **Enhanced session display**: Each session now shows:
  - Session title (first 30 characters of first user message)
  - Last message preview (40 characters)
  - Timestamp with relative time formatting
  - Message count per session
- **Improved UI spacing**: Reduced padding and font sizes to accommodate narrower width
- **Better organization**: Sessions are sorted with most recent first and grouped by conversation breaks (30-minute gaps)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a771aa540df041889c27ea202593b651/stellar-haven)

👀 [Preview Link](https://a771aa540df041889c27ea202593b651-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a771aa540df041889c27ea202593b651</projectId>-->
<!--<branchName>stellar-haven</branchName>-->