### PR TITLE
Improve chat UX: auto-focus input and simplify plan display

### DIFF
--- a/src/components/agent/Composer.tsx
+++ b/src/components/agent/Composer.tsx
@@ -11,6 +11,7 @@ interface ComposerProps {
   onFileRemove?: () => void;
   previewUrl?: string | null;
   isTyping?: boolean;
+  awaitingInput?: string | null;
 }
 
 const EMOJI_SUGGESTIONS = ["👋", "😊", "🚀", "💎", "⚡", "🎯", "🔥", "✨"];
@@ -22,7 +23,8 @@ export function Composer({
   onFileSelect,
   onFileRemove,
   previewUrl,
-  isTyping
+  isTyping,
+  awaitingInput
 }: ComposerProps) {
   const { isConnected } = useAccount();
   const [prompt, setPrompt] = useState("");
@@ -39,6 +41,17 @@ export function Composer({
       handleAutoGrow(textareaRef.current);
     }
   }, [prompt]);
+
+  // Auto-focus when SuperLee is waiting for input
+  useEffect(() => {
+    if (awaitingInput && textareaRef.current && isConnected) {
+      // Small delay to ensure UI is ready
+      const timer = setTimeout(() => {
+        textareaRef.current?.focus();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [awaitingInput, isConnected]);
 
   const handleSubmit = () => {
     const trimmedPrompt = prompt.trim();

--- a/src/components/agent/Composer.tsx
+++ b/src/components/agent/Composer.tsx
@@ -89,6 +89,27 @@ export function Composer({
     }
   }, [messages, isConnected, isTyping]);
 
+  // Preserve focus when user has typed something
+  useEffect(() => {
+    const handleDocumentClick = (e: MouseEvent) => {
+      // If user has text typed and clicks outside input, refocus after a short delay
+      if (prompt.trim() && textareaRef.current && isConnected && !isTyping) {
+        const target = e.target as Element;
+        // Don't refocus if clicking on buttons or interactive elements
+        if (!target.closest('button, a, input, select')) {
+          setTimeout(() => {
+            if (textareaRef.current && prompt.trim()) {
+              textareaRef.current.focus();
+            }
+          }, 100);
+        }
+      }
+    };
+
+    document.addEventListener('click', handleDocumentClick);
+    return () => document.removeEventListener('click', handleDocumentClick);
+  }, [prompt, isConnected, isTyping]);
+
   const handleSubmit = () => {
     const trimmedPrompt = prompt.trim();
     if ((!trimmedPrompt && !file) || !isConnected || isTyping) return;

--- a/src/components/agent/EnhancedAgentOrchestrator.tsx
+++ b/src/components/agent/EnhancedAgentOrchestrator.tsx
@@ -325,6 +325,7 @@ AI Detected: ${result.aiDetected ? 'Yes' : 'No'} (${((result.aiConfidence || 0) 
                 onFileRemove={fileUpload.removeFile}
                 previewUrl={fileUpload.previewUrl}
                 isTyping={chatAgent.isTyping}
+                awaitingInput={chatAgent.awaitingInput}
               />
             </div>
           </section>

--- a/src/components/agent/EnhancedAgentOrchestrator.tsx
+++ b/src/components/agent/EnhancedAgentOrchestrator.tsx
@@ -326,6 +326,7 @@ AI Detected: ${result.aiDetected ? 'Yes' : 'No'} (${((result.aiConfidence || 0) 
                 previewUrl={fileUpload.previewUrl}
                 isTyping={chatAgent.isTyping}
                 awaitingInput={chatAgent.awaitingInput}
+                messages={chatAgent.messages}
               />
             </div>
           </section>

--- a/src/components/agent/MessageList.tsx
+++ b/src/components/agent/MessageList.tsx
@@ -115,11 +115,17 @@ export function MessageList({ messages, onButtonClick, isTyping }: MessageListPr
                   <div className={`relative group ${
                     isUser ? "ml-2 sm:ml-4" : "mr-2 sm:mr-4"
                   }`}>
-                    <div className={`rounded-2xl px-4 py-3 shadow-sm transition-all duration-200 hover:shadow-lg hover-glow ${
-                      isUser
-                        ? "bg-gradient-to-br from-sky-500 to-sky-600 text-white rounded-br-md border border-sky-400/30 hover:from-sky-400 hover:to-sky-500"
-                        : "bg-white/8 border border-white/10 text-white rounded-tl-md hover:bg-white/12 hover:border-white/20"
-                    }`}>
+                    <div
+                      className={`rounded-2xl px-4 py-3 shadow-sm transition-all duration-200 hover:shadow-lg hover-glow ${
+                        isUser
+                          ? "bg-gradient-to-br from-sky-500 to-sky-600 text-white rounded-br-md border border-sky-400/30 hover:from-sky-400 hover:to-sky-500"
+                          : "bg-white/8 border border-white/10 text-white rounded-tl-md hover:bg-white/12 hover:border-white/20"
+                      }`}
+                      onMouseDown={(e) => {
+                        // Prevent message clicks from stealing focus from the input
+                        e.preventDefault();
+                      }}
+                    >
                       <div className="text-sm break-words font-sans leading-relaxed">
                         {message.isLoading ? (
                           <div className="flex items-center gap-2">
@@ -131,7 +137,13 @@ export function MessageList({ messages, onButtonClick, isTyping }: MessageListPr
                             </div>
                           </div>
                         ) : (
-                          <pre className="whitespace-pre-wrap">
+                          <pre
+                            className="whitespace-pre-wrap select-text"
+                            onMouseDown={(e) => {
+                              // Allow text selection but prevent focus stealing
+                              e.stopPropagation();
+                            }}
+                          >
                             {message.text}
                           </pre>
                         )}

--- a/src/components/agent/PlanBox.tsx
+++ b/src/components/agent/PlanBox.tsx
@@ -63,13 +63,11 @@ export function PlanBox({ plan, onConfirm, onCancel, swapState, registerState }:
 
   return (
     <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-4">
-      <div className="text-sm opacity-70 mb-2">Plan</div>
-      
-      <ol className="list-decimal pl-5 space-y-1 text-sm">
+      <div className="space-y-1 text-sm">
         {plan.steps.map((step, index) => (
-          <li key={index}>{step}</li>
+          <div key={index}>{step}</div>
         ))}
-      </ol>
+      </div>
 
       {/* Progress indicator */}
       {isExecuting && (

--- a/src/hooks/useChatAgent.ts
+++ b/src/hooks/useChatAgent.ts
@@ -113,11 +113,8 @@ export function useChatAgent() {
           intent: response.intent,
         });
 
-        // Show plan to user
-        const planText = [
-          "Plan:",
-          ...response.plan.map((step: string, i: number) => `${i + 1}. ${step}`)
-        ].join("\n");
+        // Show plan to user - simplified format
+        const planText = response.plan.join("\n");
 
         addMessage("agent", planText);
       }

--- a/src/hooks/useChatAgent.ts
+++ b/src/hooks/useChatAgent.ts
@@ -113,10 +113,7 @@ export function useChatAgent() {
           intent: response.intent,
         });
 
-        // Show plan to user - simplified format
-        const planText = response.plan.join("\n");
-
-        addMessage("agent", planText);
+        // Plan will be shown in PlanBox only, no need for chat message
       }
     });
   }, [addMessage, simulateTyping]);

--- a/src/lib/agent/superlee.ts
+++ b/src/lib/agent/superlee.ts
@@ -364,14 +364,10 @@ export class SuperleeEngine {
     };
     
     const plan = [
-      `Register IP: "${this.context.registerData.name}"`,
+      `Name IP : "${this.context.registerData.name}"`,
       `Description: "${this.context.registerData.description}"`,
       `License: ${license}`,
-      `AI Detected: ${this.context.registerData.aiDetected ? 'Yes' : 'No'}`,
-      "Upload file to IPFS",
-      "Build IP metadata",
-      "Mint + Register IP on Story Protocol",
-      "Show transaction result"
+      `AI Detected: ${this.context.registerData.aiDetected ? 'Yes' : 'No'}`
     ];
     
     return {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UX issues to improve the chat experience:
- Users wanted automatic focus on the input field when SuperLee requests input, eliminating the need to manually click
- Users reported that scrolling and clicking on previous messages would cancel their current typing
- Users requested simplification of the plan display format and removal of duplicate plan messages

## Code changes

### Auto-focus improvements
- Added `awaitingInput` and `messages` props to Composer component
- Implemented automatic focus detection when SuperLee asks for input using pattern matching
- Added focus preservation logic to prevent losing focus when clicking outside interactive elements
- Added mouse event prevention on message clicks to avoid stealing focus from input

### Plan display simplification
- Removed numbered list format from PlanBox, showing steps as simple text
- Updated plan generation to show simplified format: "Name IP" instead of "Register IP"
- Removed technical steps (IPFS upload, metadata building, etc.) from user-facing plan
- Eliminated duplicate plan messages in chat by removing plan text from chat messages

### Message interaction improvements
- Added `onMouseDown` preventDefault to message containers to avoid focus stealing
- Enabled text selection on messages while preventing focus loss
- Added proper event handling to maintain input focus during message interactions

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a771aa540df041889c27ea202593b651/orbit-garden)

👀 [Preview Link](https://a771aa540df041889c27ea202593b651-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a771aa540df041889c27ea202593b651</projectId>-->
<!--<branchName>orbit-garden</branchName>-->